### PR TITLE
Added annotations

### DIFF
--- a/src/the-nest/annotations.py
+++ b/src/the-nest/annotations.py
@@ -12,8 +12,7 @@ class Derived(Base):
 
 def pretty_bin(n: int, *, sep: str = " ") -> str:
     binary = f"{n:b}"
-    while len(binary) % 4 != 0:
-        binary = f"0{binary}"
+    binary = binary.zfill((len(binary) // 4 + 1) * 4)
     return sep.join(binary[i:i+4] for i in range(0, len(binary), 4))
 
 

--- a/src/the-nest/annotations.py
+++ b/src/the-nest/annotations.py
@@ -1,6 +1,7 @@
 x: int
 y: list[int | float]
 
+
 class Base:
     a: int
     b: str
@@ -13,7 +14,7 @@ class Derived(Base):
 def pretty_bin(n: int, *, sep: str = " ") -> str:
     binary = f"{n:b}"
     binary = binary.zfill((len(binary) // 4 + 1) * 4)
-    return sep.join(binary[i:i+4] for i in range(0, len(binary), 4))
+    return sep.join(binary[i : i + 4] for i in range(0, len(binary), 4))
 
 
 def main() -> None:

--- a/src/the-nest/annotations.py
+++ b/src/the-nest/annotations.py
@@ -1,0 +1,37 @@
+x: int
+y: list[int | float]
+
+class Base:
+    a: int
+    b: str
+
+
+class Derived(Base):
+    pass
+
+
+def pretty_bin(n: int, *, sep: str = " ") -> str:
+    binary = f"{n:b}"
+    while len(binary) % 4 != 0:
+        binary = f"0{binary}"
+    return sep.join(binary[i:i+4] for i in range(0, len(binary), 4))
+
+
+def main() -> None:
+    print(Base.__annotations__)
+    # {'a': <class 'int'>, 'b': <class 'str'>}
+
+    print(Derived.__annotations__)
+    # Python <=3.9: {'a': <class 'int'>, 'b': <class 'str'>}
+    # Python >=3.10: {}
+
+    print(pretty_bin(12367))  # 0011 0000 0100 1111
+    print(pretty_bin.__annotations__)
+    # {'n': <class 'int'>, 'sep': <class 'str'>, 'return': <class 'str'>}
+
+    print(__annotations__)  # module annotations
+    # {'x': <class 'int'>, 'y': list[int | float]}
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I was also considering mentioning this but I wasn't entirely sure if it's that important:
> If Python stringizes your annotations for you (using `from __future__ import annotations`), and you specify a string as an annotation, the string will itself be quoted. In effect the annotation is quoted twice. For example:
> ```py
> from __future__ import annotations
> def foo(a: "str"): pass
> 
> print(foo.__annotations__)
> ```
> This prints `{'a': "'str'"}`. This shouldn’t really be considered a “quirk”; it’s mentioned here simply because it might be surprising.

From [Annotations Best Practices](https://docs.python.org/3/howto/annotations.html#annotations-quirks)