### PR TITLE
Example for `__format__` ft. f-strings

### DIFF
--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -1,0 +1,47 @@
+from struct import pack
+
+
+class BinarizableFloat(float):
+    def __new__(cls, val, *args, **kwargs):
+        return super(BinarizableFloat, cls).__new__(cls, val)
+
+    def __format__(self, __format_spec: str) -> str:
+        if __format_spec == "b":
+            binary_as_string = "".join(
+                "{:08b}".format(b) for b in pack("f", self)
+            )
+            return binary_as_string[::-1]
+        else:
+            return super().__format__(__format_spec)
+
+
+def main():
+    integer = 32
+    float_num = 0.15625
+    binfloat = BinarizableFloat(0.15625)
+
+    print("-> An integer has a binary representation")
+    print(f"{integer=} is {type(integer)}. In binary {integer=:b}")
+
+    print("\n-> But a float does not")
+    try:
+        print(f"{float_num:b}")
+
+    except ValueError:
+        print(
+            f"{float_num=} is {type(float_num)}. No binary :("
+        )
+
+    print(
+        "\n-> BinarizableFloat returns a 32bit binary representation",
+        "following the IEEE 754 standard",
+    )
+
+    print(f"{binfloat=} is {type(binfloat)} and in binary it is {binfloat:b}")
+
+    print("\n-> BinarizableFloat can do math with the standard float")
+    print(f"{binfloat * float_num = }")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -85,7 +85,8 @@ def main():
     print(f"{binfloat ** float_num =: .6f}")
 
     ## Unit tests
-    unittest.main()
+    print("\n=== Unit tests ===")
+    unittest.main(verbosity=2)
 
 
 if __name__ == "__main__":

--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -1,21 +1,37 @@
 from struct import pack
-
+from math import isnan, isinf
 
 class BinarizableFloat(float):
     def __new__(cls, val, *args, **kwargs):
         return super(BinarizableFloat, cls).__new__(cls, val)
 
     def __format__(self, __format_spec: str) -> str:
+        """If the format specification is 'b', the IEEE 754 binary32
+        representation is returned as a string of zeros and ones. 
+        
+        The bytes are retrieved from struct.pack() assuming a float for C Type.
+        Check https://docs.python.org/3/library/struct.html#format-characters
+        for more details.
+
+        - Byte order is fixed to little-endian. 
+        - OverflowError is raised 
+        """
+
         if __format_spec == "b":
-            binary_as_string = "".join(
-                "{:08b}".format(b) for b in pack("f", self)
-            )
-            return binary_as_string[::-1]
+            # Get the four bytes in a float
+            bytes = pack(">f", self)
+
+            # Transform bytes into string of bits
+            str_bytes = "".join("{:08b}".format(b) for b in bytes)
+
+            return str_bytes
+
         else:
             return super().__format__(__format_spec)
 
 
 def main():
+    
     integer = 32
     float_num = 0.15625
     binfloat = BinarizableFloat(0.15625)
@@ -34,7 +50,6 @@ def main():
         "\n-> BinarizableFloat returns a 32bit binary representation",
         "following the IEEE 754 standard",
     )
-
     print(f"{binfloat=} is {type(binfloat)}.\nIn binary, {binfloat=:b}")
 
     print("\n-> BinarizableFloat can do math with the standard float")
@@ -42,6 +57,40 @@ def main():
     print(f"{binfloat * float_num  =: .6f}")
     print(f"{binfloat ** float_num =: .6f}")
 
+    run_tests()
 
+
+def run_tests():
+    """Run some checks for various floats"""
+
+    # Positive float
+    num = BinarizableFloat(4.20)
+    assert f"{num:b}" == "01000000100001100110011001100110"
+
+    # Negative float
+    num = BinarizableFloat(-6.9)
+    assert f"{num:b}" == "11000000110111001100110011001101"
+
+    # Zero
+    num = BinarizableFloat(0)
+    assert f"{num:b}" == "00000000000000000000000000000000"
+
+    # Negative zero
+    num = BinarizableFloat(-0.0)
+    assert f"{num:b}" == "10000000000000000000000000000000"
+
+    # Infinite
+    num = BinarizableFloat(float("inf"))
+    assert isinf(num)
+    assert f"{num:b}" == "01111111100000000000000000000000"
+
+    # Overflow
+    num = BinarizableFloat(float(8.0E+38))
+    try:
+        print(f"{num:b}")
+    except OverflowError:
+        ...
+    
 if __name__ == "__main__":
     main()
+    

--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -46,7 +46,7 @@ class BinarizableFloat(float):
         for more details.
 
         Notes:
-        - Byte order is fixed to little-endian.
+        - Byte order is fixed to big-endian.
         """
 
         if __format_spec == "b":

--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -20,27 +20,27 @@ def main():
     float_num = 0.15625
     binfloat = BinarizableFloat(0.15625)
 
-    print("-> An integer has a binary representation")
-    print(f"{integer=} is {type(integer)}. In binary {integer=:b}")
+    print("\n-> Integers have a format specification for binary")
+    print(f"{integer=} is {type(integer)}.\nIn binary, {integer=:b}")
 
     print("\n-> But a float does not")
     try:
         print(f"{float_num:b}")
 
     except ValueError:
-        print(
-            f"{float_num=} is {type(float_num)}. No binary :("
-        )
+        print(f"{float_num=} is {type(float_num)}.\nNo binary :(")
 
     print(
         "\n-> BinarizableFloat returns a 32bit binary representation",
         "following the IEEE 754 standard",
     )
 
-    print(f"{binfloat=} is {type(binfloat)} and in binary it is {binfloat:b}")
+    print(f"{binfloat=} is {type(binfloat)}.\nIn binary, {binfloat=:b}")
 
     print("\n-> BinarizableFloat can do math with the standard float")
-    print(f"{binfloat * float_num = }")
+    print(f"{binfloat + float_num  =: .6f}")
+    print(f"{binfloat * float_num  =: .6f}")
+    print(f"{binfloat ** float_num =: .6f}")
 
 
 if __name__ == "__main__":

--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -32,7 +32,6 @@ class BinarizableFloat(float):
 
 
 def main():
-
     integer = 32
     float_num = 0.15625
     binfloat = BinarizableFloat(0.15625)

--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -1,5 +1,6 @@
+from math import isinf
 from struct import pack
-from math import isnan, isinf
+
 
 class BinarizableFloat(float):
     def __new__(cls, val, *args, **kwargs):
@@ -7,14 +8,14 @@ class BinarizableFloat(float):
 
     def __format__(self, __format_spec: str) -> str:
         """If the format specification is 'b', the IEEE 754 binary32
-        representation is returned as a string of zeros and ones. 
-        
+        representation is returned as a string of zeros and ones.
+
         The bytes are retrieved from struct.pack() assuming a float for C Type.
         Check https://docs.python.org/3/library/struct.html#format-characters
         for more details.
 
-        - Byte order is fixed to little-endian. 
-        - OverflowError is raised 
+        - Byte order is fixed to little-endian.
+        - OverflowError is raised
         """
 
         if __format_spec == "b":
@@ -31,7 +32,7 @@ class BinarizableFloat(float):
 
 
 def main():
-    
+
     integer = 32
     float_num = 0.15625
     binfloat = BinarizableFloat(0.15625)
@@ -85,12 +86,12 @@ def run_tests():
     assert f"{num:b}" == "01111111100000000000000000000000"
 
     # Overflow
-    num = BinarizableFloat(float(8.0E+38))
+    num = BinarizableFloat(float(8.0e38))
     try:
         print(f"{num:b}")
     except OverflowError:
         ...
-    
+
+
 if __name__ == "__main__":
     main()
-    

--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -1,9 +1,42 @@
-import unittest
-from math import isinf
 from struct import pack
 
 
 class BinarizableFloat(float):
+    """
+    Class that inherits from float and implements a format specification
+    for printing it in binary.
+
+    >>> positive_float = BinarizableFloat(4.20)
+    >>> print(f"{positive_float:b}")
+    01000000100001100110011001100110
+
+    >>> negative_float = BinarizableFloat(-6.9)
+    >>> print(f"{negative_float:b}")
+    11000000110111001100110011001101
+
+    >>> positive_zero = BinarizableFloat(0)
+    >>> print(f"{positive_zero:b}")
+    00000000000000000000000000000000
+
+    >>> negative_zero = BinarizableFloat(-0.0)
+    >>> print(f"{negative_zero:b}")
+    10000000000000000000000000000000
+
+    >>> from math import isinf
+    >>> infinity = BinarizableFloat(float("inf"))
+    >>> print(isinf(infinity))
+    True
+
+    >>> print(f"{infinity:b}")
+    01111111100000000000000000000000
+
+    >>> overflowed_float =  BinarizableFloat(float(8.0e38))
+    >>> print(f"{overflowed_float:b}")
+    Traceback (most recent call last):
+    ...
+    OverflowError: float too large to pack with f format
+    """
+
     def __new__(cls, val, *args, **kwargs):
         return super(BinarizableFloat, cls).__new__(cls, val)
 
@@ -32,62 +65,39 @@ class BinarizableFloat(float):
             return super().__format__(__format_spec)
 
 
-class BinarizableFloatTests(unittest.TestCase):
-    def test_positive_float(self):
-        num = BinarizableFloat(4.20)
-        self.assertEqual(f"{num:b}", "01000000100001100110011001100110")
-
-    def test_negative_float(self):
-        num = BinarizableFloat(-6.9)
-        self.assertEqual(f"{num:b}", "11000000110111001100110011001101")
-
-    def test_zeroes(self):
-        num = BinarizableFloat(0)
-        self.assertEqual(f"{num:b}", "00000000000000000000000000000000")
-
-        num = BinarizableFloat(-0.0)
-        self.assertEqual(f"{num:b}", "10000000000000000000000000000000")
-
-    def test_infty(self):
-        num = BinarizableFloat(float("inf"))
-        self.assertTrue(isinf(num))
-        self.assertEqual(f"{num:b}", "01111111100000000000000000000000")
-
-    def test_overflow(self):
-        BinarizableFloat(float(8.0e38))
-        self.assertRaises(OverflowError)
-
-
 def main():
     integer = 32
     float_num = 0.15625
-    binfloat = BinarizableFloat(0.15625)
+    binfloat = BinarizableFloat(float_num)
 
-    print("\n-> Integers have a format specification for binary")
-    print(f"{integer=} is {type(integer)}.\nIn binary, {integer=:b}")
+    print("-> Integers have a format specification for binary")
+    print(f"{integer=} is {type(integer).__name__}.\nIn binary, {integer=:b}")
 
     print("\n-> But a float does not")
     try:
         print(f"{float_num:b}")
 
     except ValueError:
-        print(f"{float_num=} is {type(float_num)}.\nNo binary :(")
+        print(f"{float_num=} is {type(float_num).__name__}.\nNo binary :(")
 
     print(
-        "\n-> BinarizableFloat returns a 32bit binary representation",
+        "\n-> BinarizableFloat returns a 32-bit binary representation",
         "following the IEEE 754 standard",
     )
-    print(f"{binfloat=} is {type(binfloat)}.\nIn binary, {binfloat=:b}")
+    print(
+        f"{binfloat=} is {type(binfloat).__name__}.",
+        f"\nIn binary, {binfloat=:b}",
+    )
 
     print("\n-> BinarizableFloat can do math with the standard float")
     print(f"{binfloat + float_num  =: .6f}")
     print(f"{binfloat * float_num  =: .6f}")
     print(f"{binfloat ** float_num =: .6f}")
 
-    ## Unit tests
-    print("\n=== Unit tests ===")
-    unittest.main(verbosity=2)
-
 
 if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
     main()

--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -14,8 +14,8 @@ class BinarizableFloat(float):
         Check https://docs.python.org/3/library/struct.html#format-characters
         for more details.
 
+        Notes:
         - Byte order is fixed to little-endian.
-        - OverflowError is raised
         """
 
         if __format_spec == "b":

--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -37,9 +37,6 @@ class BinarizableFloat(float):
     OverflowError: float too large to pack with f format
     """
 
-    def __new__(cls, val, *args, **kwargs):
-        return super(BinarizableFloat, cls).__new__(cls, val)
-
     def __format__(self, __format_spec: str) -> str:
         """If the format specification is 'b', the IEEE 754 binary32
         representation is returned as a string of zeros and ones.

--- a/src/middle-earth/format.py
+++ b/src/middle-earth/format.py
@@ -1,3 +1,4 @@
+import unittest
 from math import isinf
 from struct import pack
 
@@ -31,6 +32,32 @@ class BinarizableFloat(float):
             return super().__format__(__format_spec)
 
 
+class BinarizableFloatTests(unittest.TestCase):
+    def test_positive_float(self):
+        num = BinarizableFloat(4.20)
+        self.assertEqual(f"{num:b}", "01000000100001100110011001100110")
+
+    def test_negative_float(self):
+        num = BinarizableFloat(-6.9)
+        self.assertEqual(f"{num:b}", "11000000110111001100110011001101")
+
+    def test_zeroes(self):
+        num = BinarizableFloat(0)
+        self.assertEqual(f"{num:b}", "00000000000000000000000000000000")
+
+        num = BinarizableFloat(-0.0)
+        self.assertEqual(f"{num:b}", "10000000000000000000000000000000")
+
+    def test_infty(self):
+        num = BinarizableFloat(float("inf"))
+        self.assertTrue(isinf(num))
+        self.assertEqual(f"{num:b}", "01111111100000000000000000000000")
+
+    def test_overflow(self):
+        BinarizableFloat(float(8.0e38))
+        self.assertRaises(OverflowError)
+
+
 def main():
     integer = 32
     float_num = 0.15625
@@ -57,39 +84,8 @@ def main():
     print(f"{binfloat * float_num  =: .6f}")
     print(f"{binfloat ** float_num =: .6f}")
 
-    run_tests()
-
-
-def run_tests():
-    """Run some checks for various floats"""
-
-    # Positive float
-    num = BinarizableFloat(4.20)
-    assert f"{num:b}" == "01000000100001100110011001100110"
-
-    # Negative float
-    num = BinarizableFloat(-6.9)
-    assert f"{num:b}" == "11000000110111001100110011001101"
-
-    # Zero
-    num = BinarizableFloat(0)
-    assert f"{num:b}" == "00000000000000000000000000000000"
-
-    # Negative zero
-    num = BinarizableFloat(-0.0)
-    assert f"{num:b}" == "10000000000000000000000000000000"
-
-    # Infinite
-    num = BinarizableFloat(float("inf"))
-    assert isinf(num)
-    assert f"{num:b}" == "01111111100000000000000000000000"
-
-    # Overflow
-    num = BinarizableFloat(float(8.0e38))
-    try:
-        print(f"{num:b}")
-    except OverflowError:
-        ...
+    ## Unit tests
+    unittest.main()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
_Problem:_
For an integer, `f"{10:b}"` returns `'1010'` :)
For a float, `f"{10.0:b}"` raises a `ValueError` :(

_Goal:_
`f"{10.0:b}"` returns the string of 32bits `01000001001000000000000000000000`

_Solution:_
Defined a class that inherits from `float` and implements a format specification for binary. 

______

Not sure if inheriting from `float` was done correctly. 

