### PR TITLE
Add `__import__`

### DIFF
--- a/src/module-mesa/import_function.py
+++ b/src/module-mesa/import_function.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import builtins
+import sys
+from contextlib import suppress
+from collections.abc import Mapping, Sequence
+
+
+def import_called(
+    name: str,
+    globals: Mapping[str, object] | None = None,
+    locals: Mapping[str, object] | None = None,
+    fromlist: Sequence[str] = (),
+    level: int = 0,
+) -> None:
+    print(name, fromlist, level)
+
+__import__ = import_called
+
+import plistlib  # doesn't work
+
+# remove from cache
+del plistlib
+del sys.modules["plistlib"]
+
+builtins.__import__ = import_called
+
+import plistlib  # works
+# plistlib None 0
+
+with suppress(ImportError):
+    from plistlib import FMT_BINARY
+    # plistlib ('FMT_BINARY',) 0


### PR DESCRIPTION
I imagine a script illustrating `__import__` should:

- show how all `import X`/`import X.Y`/`from X import Y` (and other variants) work under the hood with `__import__`
- highlight that `__import__` != `importlib.import_module`
- mention `importlib._bootstrap.__import__`
- present the caching mechanism of modules
- optionally show module lock acquires/releases
- whatever else you suggest
